### PR TITLE
Adds a robust set of basic SPI Pico <--> ESP32 methods

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@
 //!
 //! This application demonstrates how to use the SPI Driver to talk to a remote
 //! ESP32 wifi SPI device.
+//! 
+//! It's based off of the Pimoroni C++ code located here:
+//! https://github.com/pimoroni/pimoroni-pico/tree/main/examples/pico_wireless
 //!
 //! See the `Cargo.toml` file for Copyright and licence details.
 
@@ -137,7 +140,6 @@ impl SpiDrv {
     fn get_param(&mut self) -> Result<u8, nb::Error<core::convert::Infallible>> {
         // Blocking read, don't return until we've read a byte successfully
         loop {
-            //let read_result = self.spi.read();
             let word_out = &mut[DUMMY_DATA];
             let read_result = self.spi.transfer(word_out);
             match read_result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ impl SpiDrv {
             match result {
                 Ok(byte_read) => {
                     if byte_read == ERR_CMD {
-                        return Ok(false);
+                        return Err(nb::Error::WouldBlock);
                     } else if byte_read == wait_byte {
                         return Ok(true);
                     } else if timeout == 0 {
@@ -273,10 +273,18 @@ impl SpiDrv {
                             cmd & !(REPLY_FLAG),
                             num_param];
         for byte in buf {
-            let transfer_results = self.spi.send(byte);
+            let byte_buf = &mut[byte];
+            // let transfer_results = self.spi.send(byte);
+            let transfer_results = self.spi.transfer(byte_buf);
             match transfer_results {
-                Ok(_) => { continue; }
-                Err(e) => { continue; }
+                Ok(byte) => { 
+                  write!(uart, "\tsend_cmd successful: 0x{:X?}\r\n", byte).ok().unwrap();
+                  continue; 
+                }
+                Err(e) => {
+                  write!(uart, "\tsend_cmd error: 0x{:X?}\r\n", e).ok().unwrap();
+                  continue; 
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds a robust set of fundamental SPI communication methods for the Pico to communicate with the ESP32 WiFi board from Pimoroni. It can do the following high level functions from the Wifi API that Pimoroni created and the ESP32 expects over the SPI bus:

1. Get the ESP32 firmware version
2. Set the onboard multi-color LED, RGB values

When you run this you should be able to verify:

- The ESP32 LED should go red, delay 1s, green, delay 1s, blue, delay 1s, then a blend of all three colors
- Then it should request the ESP32 firmware version and display that in the debug console