### PR TITLE
feat: add pad_to_multiple_of_4 method to SpiDrv

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -420,6 +420,13 @@ impl SpiDrv {
         //     self.send_param(uart, param, last_param);
         // });
     }
+
+    fn pad_to_multiple_of_4(&mut self, uart: &mut EnabledUart, mut cmd: u8) {
+        while cmd % 4 == 0 {
+            self.read_byte(uart);
+            cmd += 1;
+        }
+    }
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,10 +421,11 @@ impl SpiDrv {
         // });
     }
 
-    fn pad_to_multiple_of_4(&mut self, uart: &mut EnabledUart, mut cmd: u8) {
-        while cmd % 4 == 0 {
+    fn pad_to_multiple_of_4(&mut self, uart: &mut EnabledUart, cmd: u8) {
+        let mut cmd_to_pad = cmd;
+        while cmd_to_pad % 4 == 0 {
             self.read_byte(uart);
-            cmd += 1;
+            cmd_to_pad += 1;
         }
     }
 }


### PR DESCRIPTION
Add pad_to_multiple_of_4 method to SpiDrv
Based on cpp function [pad_to_multiple_of_4](https://github.com/pimoroni/pimoroni-pico/blob/main/drivers/esp32spi/spi_drv.cpp#L304) used in [Esp32Spi::wifi_set_passphrase function from esp32spi.cpp](https://github.com/pimoroni/pimoroni-pico/blob/main/drivers/esp32spi/esp32spi.cpp#L152)

[Related project card for this feature work.](https://github.com/orgs/Jim-Hodapp-Coaching/projects/3/views/1)