### PR TITLE
feat/add_wifi_connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main"
 cortex-m-semihosting = "0.3.7"
 panic-halt = "0.2.0"
 nb = "1.0"
+heapless = "0.7.10"
 
 [features]
 default = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ use embedded_hal::blocking::delay::DelayMs;
 
 use crate::hal::spi::Enabled;
 
+use heapless::Vec;
+use heapless::String;
+
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
@@ -59,11 +62,13 @@ const REPLY_FLAG: u8 = 1 << 7;
 const DATA_FLAG: u8 = 0x40u8;
 
 const PARAMS_ARRAY_LEN: usize = 8;
+const STR_LEN: usize = 24;
 
 const ESP_LED_R: u8 = 25;
 const ESP_LED_G: u8 = 26;
 const ESP_LED_B: u8 = 27;
 
+const SET_PASSPHRASE: u8 = 0x11u8;
 const GET_FW_VERSION: u8 = 0x37u8;
 
 const SET_ANALOG_WRITE: u8 = 0x52u8;
@@ -72,6 +77,8 @@ type SpiResult<T> = Result<T, nb::Error<core::convert::Infallible>>;
 
 type EnabledUart = hal::uart::UartPeripheral<rp2040_hal::uart::Enabled, pac::UART0,
     (rp2040_hal::gpio::Pin<Gpio0, rp2040_hal::gpio::Function<rp2040_hal::gpio::Uart>>, rp2040_hal::gpio::Pin<Gpio1, rp2040_hal::gpio::Function<rp2040_hal::gpio::Uart>>)>;
+
+type Params = Vec::<u8, PARAMS_ARRAY_LEN>;
 
 struct Esp32Pins {
     cs: Pin<Gpio7, hal::gpio::PushPullOutput>,
@@ -323,20 +330,21 @@ impl SpiDrv {
     }
 
     // TODO: replace last_param with an enumerated type, e.g. NO_LAST_PARAM, LAST_PARAM
-    fn send_param(&mut self, uart: &mut EnabledUart, param: u8, param_len: u8, last_param: bool) -> SpiResult<()> {
+    fn send_param(&mut self, uart: &mut EnabledUart, params: Params, param_len: u8, last_param: bool) -> SpiResult<()> {
         let res = self.send_param_len8(uart, param_len);
         match res {
             Ok(_) => {
                 // TODO: this doesn't quite match the C++ code yet, seems it can send a
                 // variable length buf
-                let byte_buf = &mut[param];
-                write!(uart, "\t\tsending byte: 0x{:X?} -> ", param).ok().unwrap();
+                let byte_buf = &mut[params[0]];
+                write!(uart, "\t\tsending byte: 0x{:X?} -> ", params[0]).ok().unwrap();
+  
                 let transfer_results = self.spi.transfer(byte_buf);
                 match transfer_results {
                     Ok(byte) => {
                         write!(uart, "read byte: 0x{:X?}\r\n", byte).ok().unwrap();
                         if last_param {
-                            write!(uart, "\t\t\tsending byte: 0x{:X?} -> ", param).ok().unwrap();
+                            write!(uart, "\t\t\tsending byte: 0x{:X?} -> ", params[0]).ok().unwrap();
                             let transfer_results = self.spi.transfer(byte_buf);
                             match transfer_results {
                                 Ok(byte) => {
@@ -391,7 +399,30 @@ impl SpiDrv {
             Err(e) => { return Err(e); }
         }
     }
+
+    fn send_param_string(&mut self, uart: &mut EnabledUart, param_string: String<STR_LEN>, last_param: bool) -> SpiResult<()> {
+      let mut i: u8 = 0;
+      let mut param_bytes: String<STR_LEN> = param_string.into_bytes().iter().rev().collect();
+      loop {
+        let byte = match param_bytes.pop() {
+            Some(byte) => byte,
+            None => return Ok(())
+        };
+        let mut param: Params = Params::new();
+        param.push(byte).unwrap();
+        let result = self.send_param(uart, param, 1, last_param);
+        // Exit when we reach a '\n':
+        if byte == 0xD {
+           return result;
+        }
+        i += 1;
+        if i == STR_LEN as u8 {
+           return result;
+        }
+      }
+    }
 }
+
 
 fn set_led(spi_drv: &mut SpiDrv, uart: &mut EnabledUart, red: u8, green: u8, blue: u8) {
     write!(uart, "Calling analog_write(ESP_LED_R, {:?})\r\n", 255 - red).ok().unwrap();
@@ -411,9 +442,13 @@ fn analog_write(spi_drv: &mut SpiDrv, uart: &mut EnabledUart, pin: u8, value: u8
     uart.write_full_blocking(b"\tsend_cmd(SET_ANALOG_WRITE)\r\n");
     spi_drv.send_cmd(uart, SET_ANALOG_WRITE, 2).ok().unwrap();
     uart.write_full_blocking(b"\tsend_param(pin)\r\n");
-    spi_drv.send_param(uart, pin, 1, false).ok().unwrap();
+    let mut pin_param: Params = Params::new();
+    pin_param.push(pin).unwrap();
+    spi_drv.send_param(uart, pin_param, 1, false).ok().unwrap();
     uart.write_full_blocking(b"\tsend_param(value)\r\n");
-    spi_drv.send_param(uart, value, 1, true).ok().unwrap(); // LAST_PARAM
+    let mut value_param: Params = Params::new();
+    value_param.push(value).unwrap();
+    spi_drv.send_param(uart, value_param, 1, true).ok().unwrap(); // LAST_PARAM
 
     uart.write_full_blocking(b"\tread_byte()\r\n");
     spi_drv.read_byte(uart).ok().unwrap();
@@ -443,6 +478,18 @@ fn analog_write(spi_drv: &mut SpiDrv, uart: &mut EnabledUart, pin: u8, value: u8
 
     uart.write_full_blocking(b"\tesp_deselect()\r\n");
     spi_drv.esp_deselect();
+}
+
+fn wifi_set_passphrase(spi_drv: &mut SpiDrv, uart: &mut EnabledUart, ssid: String<STR_LEN>, passphrase: String<STR_LEN>) -> bool {
+    spi_drv.wait_for_esp_select();
+
+    // Send Command
+    spi_drv.send_cmd(uart, SET_PASSPHRASE, 2);
+    spi_drv.send_param_string(uart, ssid, false);
+ 
+    spi_drv.esp_deselect();
+
+    true
 }
 
 /// Entry point to our bare-metal application.
@@ -595,6 +642,8 @@ fn main() -> ! {
     uart.write_full_blocking(b"esp_deselect()\r\n");
 
     // --- end get_fw_version() ---
+
+    wifi_set_passphrase(&mut spi_drv, &mut uart, String::from("creamandshug\n"), String::from("password\n"));
 
     let mut led_pin = pins.gpio25.into_push_pull_output();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,22 +405,6 @@ impl SpiDrv {
         }
     }
 
-    fn send_param_string(&mut self, uart: &mut EnabledUart, param_string: String<STR_LEN>) -> () {
-        // let param_bytes: Vec<u8, STR_LEN> = param_string.into_bytes();
-        let param_bytes: &[u8] = param_string.as_bytes();
-        // param_bytes.iter().enumerate().for_each(|(i, byte)| {
-        //     let mut param: Params = Params::new();
-        //     param.push(*byte).unwrap();
-        //     // set last_param to true if this is the last byte in the sequence
-        //     let last_param: bool = i == (param_bytes.len() - 1);
-        //     write!(uart, "\tsend_param_string() is sending ascii character: {}\r\n", *byte as char);
-
-        //     if last_param { uart.write_full_blocking(b"\tsend_param_string() sending last_param\r\n"); };
-
-        //     self.send_param(uart, param, last_param);
-        // });
-    }
-
     fn pad_to_multiple_of_4(&mut self, uart: &mut EnabledUart, mut command_size: u8) {
         while command_size % 4 == 0 {
             self.read_byte(uart).ok().unwrap();
@@ -428,7 +412,6 @@ impl SpiDrv {
         }
     }
 }
-
 
 fn set_led(spi_drv: &mut SpiDrv, uart: &mut EnabledUart, red: u8, green: u8, blue: u8) {
     write!(uart, "Calling analog_write(ESP_LED_R, {:?})\r\n", 255 - red).ok().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,11 +422,10 @@ impl SpiDrv {
         // });
     }
 
-    fn pad_to_multiple_of_4(&mut self, uart: &mut EnabledUart, cmd: u8) {
-        let mut cmd_to_pad = cmd;
-        while cmd_to_pad % 4 == 0 {
+    fn pad_to_multiple_of_4(&mut self, uart: &mut EnabledUart, mut cmd: u8) {
+        while cmd % 4 == 0 {
             self.read_byte(uart);
-            cmd_to_pad += 1;
+            cmd += 1;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,10 +336,7 @@ impl SpiDrv {
             Ok(_) => {
                 // TODO: this doesn't quite match the C++ code yet, seems it can send a
                 // variable length buf
-                // let mut byte_buf: [u8; param_len] =  params.into_array().unwrap();
-                // let byte_buf = &mut[params[0]];
                 let byte_buf = params;
-                //write!(uart, "\t\tsending bytes: 0x{:X?} -> ", params).ok().unwrap();
                 let transfer_results = self.spi.transfer(byte_buf);
                 match transfer_results {
                     Ok(transfer_buf) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,73 +633,10 @@ fn main() -> ! {
     spi_drv.init();
     spi_drv.reset(&mut delay);
 
-    // // Turn the ESP32's onboard multi-color LED off
-    // set_led(&mut spi_drv, &mut uart, 0, 0, 0);
-    // delay.delay_ms(500);
-
-    // set_led(&mut spi_drv, &mut uart, 255, 0, 0);
-    // delay.delay_ms(1000);
-    // set_led(&mut spi_drv, &mut uart, 0, 255, 0);
-    // delay.delay_ms(1000);
-    // set_led(&mut spi_drv, &mut uart, 0, 0, 255);
-    // delay.delay_ms(1000);
-    // set_led(&mut spi_drv, &mut uart, 100, 100, 100);
-
-    // uart.write_full_blocking(b"-----------------\r\n");
-    // writeln!(uart, "START_CMD 0x{:X?}\r", START_CMD).ok().unwrap();
-    // writeln!(uart, "END_CMD 0x{:X?}\r", END_CMD).ok().unwrap();
-    // writeln!(uart, "REPLY_FLAG 0x{:X?}\r", REPLY_FLAG).ok().unwrap();
-    // uart.write_full_blocking(b"-----------------\r\n");
-
-    // // --- get_fw_version() ---
-    // uart.write_full_blocking(b"wait_for_esp_select()\r\n");
-    // spi_drv.wait_for_esp_select();
-    // uart.write_full_blocking(b"\tesp selected\r\n");
-
-    // uart.write_full_blocking(b"send_cmd(GET_FW_VERSION)\r\n");
-    // let results = spi_drv.send_cmd(&mut uart, GET_FW_VERSION, 0);
-    // match results {
-    //     Ok(_) => { uart.write_full_blocking(b"\tsent GET_FW_VERSION command\r\n"); }
-    //     Err(e) => { writeln!(uart, "\t** Failed to send GET_FW_VERSION command: {:?}\r\n", e).ok().unwrap(); }
-    // }
-
-    // spi_drv.esp_deselect();
-    // uart.write_full_blocking(b"esp_deselect()\r\n");
-
-    // uart.write_full_blocking(b"\r\nNow waiting for firmware version response...\r\n");
-    // uart.write_full_blocking(b"wait_for_esp_select()\r\n");
-    // spi_drv.wait_for_esp_select();
-    // uart.write_full_blocking(b"\tesp selected\r\n");
-
-    // // Get the ESP32 firmware version
-    // uart.write_full_blocking(b"wait_response_cmd()\r\n");
-    // let wait_response = spi_drv.wait_response_cmd(&mut uart, GET_FW_VERSION, 1);
-    // match wait_response {
-    //     Ok(params) => {
-    //         write!(uart, "\tESP32 firmware version: ").ok().unwrap();
-    //         for byte in params {
-    //             let c = byte as char;
-    //             write!(uart, "{:?}", c).ok().unwrap();
-    //         }
-    //         writeln!(uart, "\r\n").ok().unwrap();
-    //     }
-    //     Err(e) => {
-    //         writeln!(uart, "\twait_response_cmd(GET_FW_VERSION) Err: {:?}\r", e)
-    //             .ok()
-    //             .unwrap() 
-    //     }
-    // }
-    // uart.write_full_blocking(b"wait_response_cmd() returned\r\n");
-
-    // spi_drv.esp_deselect();
-    // uart.write_full_blocking(b"esp_deselect()\r\n");
-
-    // // --- end get_fw_version() ---
     unsafe {
         wifi_set_passphrase(&mut spi_drv, &mut uart, String::from("ssid"), String::from("password"));
     }
     delay.delay_ms(1000);
-    
 
     let mut led_pin = pins.gpio25.into_push_pull_output();
 
@@ -709,12 +646,6 @@ fn main() -> ! {
         if connected != true {
             set_led(&mut spi_drv, &mut uart, 0, 255, 0);
         }
-
-        // if i % 2 == 0 {
-        //     led_pin.set_high().unwrap();
-        // } else {
-        //     led_pin.set_low().unwrap();
-        // }
 
         write!(uart, "Loop ({:?}) ...\r", i).ok().unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,24 +562,24 @@ fn get_fw_version(spi_drv: &mut SpiDrv, uart: &mut EnabledUart) -> bool {
     uart.write_full_blocking(b"\tesp selected\r\n");
 
     // Get the ESP32 firmware version
-     uart.write_full_blocking(b"wait_response_cmd()\r\n");
-     let wait_response = spi_drv.wait_response_cmd(uart, GET_FW_VERSION, 1);
-     match wait_response {
-         Ok(params) => {
-             write!(uart, "\tESP32 firmware version: ").ok().unwrap();
-             for byte in params {
-                 let c = byte as char;
-                 write!(uart, "{:?}", c).ok().unwrap();
-             }
-             writeln!(uart, "\r\n").ok().unwrap();
-         }
-         Err(e) => {
-             writeln!(uart, "\twait_response_cmd(GET_FW_VERSION) Err: {:?}\r", e)
-                 .ok()
-                 .unwrap();
+    uart.write_full_blocking(b"wait_response_cmd()\r\n");
+    let wait_response = spi_drv.wait_response_cmd(uart, GET_FW_VERSION, 1);
+    match wait_response {
+        Ok(params) => {
+            write!(uart, "\tESP32 firmware version: ").ok().unwrap();
+                for byte in params {
+                    let c = byte as char;
+                    write!(uart, "{:?}", c).ok().unwrap();
+            }
+            writeln!(uart, "\r\n").ok().unwrap();
+        }
+        Err(e) => {
+            writeln!(uart, "\twait_response_cmd(GET_FW_VERSION) Err: {:?}\r", e)
+                .ok()
+                .unwrap();
             return false;
-         }
-     }
+        }
+    }
     uart.write_full_blocking(b"wait_response_cmd() returned\r\n");
     spi_drv.esp_deselect();
     uart.write_full_blocking(b"esp_deselect()\r\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,26 +400,12 @@ impl SpiDrv {
         }
     }
 
-    fn send_param_string(&mut self, uart: &mut EnabledUart, param_string: String<STR_LEN>, last_param: bool) -> SpiResult<()> {
-      let mut i: u8 = 0;
-      let mut param_bytes: String<STR_LEN> = param_string.into_bytes().iter().rev().collect();
-      loop {
-        let byte = match param_bytes.pop() {
-            Some(byte) => byte,
-            None => return Ok(())
-        };
-        let mut param: Params = Params::new();
-        param.push(byte).unwrap();
-        let result = self.send_param(uart, param, 1, last_param);
-        // Exit when we reach a '\n':
-        if byte == 0xD {
-           return result;
-        }
-        i += 1;
-        if i == STR_LEN as u8 {
-           return result;
-        }
-      }
+    fn send_param_string(&mut self, uart: &mut EnabledUart, param_string: String<STR_LEN>, last_param: bool) -> () {
+        param_string.into_bytes().iter().for_each(|byte| {
+            let mut param: Params = Params::new();
+            param.push(*byte).unwrap();
+            self.send_param(uart, param, 1, last_param);
+        });
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,6 +633,7 @@ fn main() -> ! {
     spi_drv.init();
     spi_drv.reset(&mut delay);
 
+    // Set wifi passphrase - ESP32 will attempt to connect after receving this cmd
     unsafe {
         wifi_set_passphrase(&mut spi_drv, &mut uart, String::from("ssid"), String::from("password"));
     }
@@ -642,6 +643,7 @@ fn main() -> ! {
 
     let mut i: u32 = 0;
     loop {
+        // Check for connection in loop and set led on if connected succesfully
         let connected = get_connection_status(&mut spi_drv, &mut uart);
         if connected != true {
             set_led(&mut spi_drv, &mut uart, 0, 255, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -696,7 +696,7 @@ fn main() -> ! {
 
     // // --- end get_fw_version() ---
     unsafe {
-        wifi_set_passphrase(&mut spi_drv, &mut uart, String::from("creamandshug"), String::from("burgerbalogna"));
+        wifi_set_passphrase(&mut spi_drv, &mut uart, String::from("ssid"), String::from("password"));
     }
     delay.delay_ms(1000);
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -692,7 +692,7 @@ fn main() -> ! {
     loop {
         // Check for connection in loop and set led on if connected succesfully
         let connected = get_connection_status(&mut spi_drv, &mut uart);
-        if connected != true {
+        if connected == true {
             // Set ESP32 LED green when successfully connected to WiFi AP
             set_led(&mut spi_drv, &mut uart, 0, 255, 0);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -484,21 +484,21 @@ fn analog_write(spi_drv: &mut SpiDrv, uart: &mut EnabledUart, pin: u8, value: u8
     spi_drv.esp_deselect();
 }
 
-unsafe fn wifi_set_passphrase(spi_drv: &mut SpiDrv, uart: &mut EnabledUart, mut ssid: String<STR_LEN>, mut passphrase: String<STR_LEN>) -> bool {
+fn wifi_set_passphrase(spi_drv: &mut SpiDrv, uart: &mut EnabledUart, mut ssid: String<STR_LEN>, mut passphrase: String<STR_LEN>) -> bool {
     spi_drv.wait_for_esp_select();
 
     // Send Command
     spi_drv.send_cmd(uart, SET_PASSPHRASE, 2).ok().unwrap();
 
-    let ssid_bytes: &mut [u8] = ssid.as_bytes_mut();
-    let (bytes, _) = ssid_bytes.split_at_mut(ssid_bytes.len());
-    writeln!(uart, "ssid: {:?}\r", bytes).ok().unwrap();
-    spi_drv.send_param(uart, bytes, false).ok().unwrap();
+    // FIXME: for the real crate, don't use unsafe
+    let ssid_bytes: &mut [u8] = unsafe { ssid.as_bytes_mut() };
+    writeln!(uart, "ssid: {:?}\r", ssid_bytes).ok().unwrap();
+    spi_drv.send_param(uart, ssid_bytes, false).ok().unwrap();
 
-    let passphrase_bytes: &mut [u8] = passphrase.as_bytes_mut();
-    let (bytes, _) = passphrase_bytes.split_at_mut(passphrase_bytes.len());
-    writeln!(uart, "passphrase: {:?}\r", bytes).ok().unwrap();
-    spi_drv.send_param(uart, bytes, true).ok().unwrap();
+    // FIXME: for the real crate, don't use unsafe
+    let passphrase_bytes: &mut [u8] = unsafe { passphrase.as_bytes_mut() };
+    writeln!(uart, "passphrase: {:?}\r", passphrase_bytes).ok().unwrap();
+    spi_drv.send_param(uart, passphrase_bytes, true).ok().unwrap();
 
     let command_size: u8 = 6 + ssid.len() as u8 + passphrase.len() as u8;
     spi_drv.pad_to_multiple_of_4(uart, command_size);


### PR DESCRIPTION
# Add functions necessary for wifi connection

- wifi_set_passphrase: sends command to Esp32 with wifi ssid and password and the module will attempt to establish connection
- get_connection_status: returns status of Esp32 connection with the network
- get_fw_version: refactored version of code used previously to determine Esp32 firmware version

# How to run ?

Main function will make Pico send a command to Esp32 with passphrase to wifi in order to perform a connection to wifi.  Secondly a loop will be ran and connection status will be checked. If it's successful it will light up a led on the Esp32 board. 

- Thus you must put your WiFi's ssid and password into src/main.rs (this will be changed in future)
- Remember that Esp32 functions on 2.4 GHz only

# Notes

- Hardcoding WiFi SSID and password must be changed to drawing from local config or environment variables