### PR TITLE
Add pre-commit code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ needed at minimum, and some suggested items to make your life even easier.
 5. [Saleae Logic 8](https://www.saleae.com/) (1x)
    * __Note__: Only needed if you'd like to participate in developing/debugging parts of this project that communicate
    on the SPI/I2C buses
-   
+
 ### Wiring Details
 
 Start with the section [Pico to Pico Wiring in this article](https://reltech.substack.com/p/getting-started-with-rust-on-a-raspberry?s=w) to set up using two Picos together, one as a Picoprobe (flash/debug) and the other as your embedded target.
@@ -109,6 +109,15 @@ rustup target install thumbv6m-none-eabi
 cargo install flip-link
 cargo add panic_halt
 ```
+
+## Set Up Git Hooks
+
+The esp32-pico-wifi repository makes use of several Git hooks to ensure that code quality standards are met and consistent. To automatically configure these hooks for your local workspace, you can run the following:
+```bash
+./scripts/create-git-hooks
+```
+
+This will create symlinks to the Git hooks, preserving any hooks that you may have already configured.
 
 ## Running
 

--- a/scripts/create-git-hooks
+++ b/scripts/create-git-hooks
@@ -1,0 +1,29 @@
+# This script was taken from a StackOverflow answer that can be found at
+# https://stackoverflow.com/a/3464399
+#
+# This is used under the CC BY-SA 4.0 license:
+# https://creativecommons.org/licenses/by-sa/4.0/
+#
+# This file has been modified from its original form to include a BASE_DIR variable
+# and to include creation of the Git hooks directory if it does not already exist
+
+
+#!/bin/bash
+HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-receive update post-receive post-update pre-auto-gc"
+BASE_DIR=$(git rev-parse --show-toplevel)
+HOOK_DIR=$BASE_DIR/.git/hooks
+
+if [ ! -d $HOOK_DIR ]; then
+  mkdir $HOOK_DIR
+fi
+
+for hook in $HOOK_NAMES; do
+    # If the hook already exists, is executable, and is not a symlink
+    if [ ! -h $HOOK_DIR/$hook -a -x $HOOK_DIR/$hook ]; then
+        mv $HOOK_DIR/$hook $HOOK_DIR/$hook.local
+    fi
+    # create the symlink, overwriting the file if it exists
+    # probably the only way this would happen is if you're using an old version of git
+    # -- back when the sample hooks were not executable, instead of being named ____.sample
+    ln -s -f $BASE_DIR/scripts/hooks-wrapper $HOOK_DIR/$hook
+done

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eo pipefail
+
+cargo fmt
+
+# Stage changes to files that were already staged
+git update-index --again

--- a/scripts/hooks-wrapper
+++ b/scripts/hooks-wrapper
@@ -1,0 +1,12 @@
+# This script was taken from a StackOverflow answer that can be found at
+# https://stackoverflow.com/a/3464399
+# This is used under the CC BY-SA 4.0 license:
+# https://creativecommons.org/licenses/by-sa/4.0/
+
+#!/bin/bash
+if [ -x $0.local ]; then
+    $0.local "$@" || exit $?
+fi
+if [ -x scripts/git/$(basename $0) ]; then
+    scripts/git/$(basename $0) "$@" || exit $?
+fi


### PR DESCRIPTION
This change adds a new pre-commit hook that will run `cargo fmt` and add the changed files to the commit. This ensures that all of the code in the repository meets our code quality standards, and removes the responsibility of running the `fmt` command from the author so that they are not forced to remember and reviewers do not need to ask for formatting updates. This also conveniently adds the updates to the commit containing the changed files so that the author does not need to do any squashing or fixing up later.

To install the new commit hook in your local workspace, you can run `./scripts/create-git-hooks`, which will set up a symlink to a hooks-wrapper script that can run any commit hook that we currently have or add in the future.