### PR TITLE
Add BME280 support, embedded-hal-1.0.0, and probe-run

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -18,3 +18,7 @@ rustflags = [
 
 [build]
 target = "thumbv6m-none-eabi"
+
+[env]
+# Set the level of debug output to display from the target application
+DEFMT_LOG = "debug"

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,25 +1,19 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "arm-none-eabi-gdb -q -x openocd.gdb"
-# runner = "probe-run-rp --chip RP2040"
+runner = "probe-run --chip RP2040"
+#runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 
 rustflags = [
-  "-C",
-  "linker=flip-link",
-  "-C",
-  "link-arg=--nmagic",
-  "-C",
-  "link-arg=-Tlink.x",
-  "-C",
-  "link-arg=-Tdefmt.x",
+  "-C", "linker=flip-link",
+  "-C", "link-arg=--nmagic",
+  "-C", "link-arg=-Tlink.x",
+  "-C", "link-arg=-Tdefmt.x",
 
   # Code-size optimizations.
   #   trap unreachable can save a lot of space, but requires nightly compiler.
   #   uncomment the next line if you wish to enable it
   # "-Z", "trap-unreachable=no",
-  "-C",
-  "inline-threshold=5",
-  "-C",
-  "no-vectorize-loops",
+  "-C", "inline-threshold=5",
+  "-C", "no-vectorize-loops",
 ]
 
 [build]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,15 @@ resolver = "2"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
-embedded-hal = { version = "0.2.5", features=["unproven"] }
+embedded-hal-02 = { version = "0.2.7", package="embedded-hal"  }
+embedded-hal = { version = "=1.0.0-alpha.7" }
 embedded-time = "0.12.0"
 
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
-panic-probe = { version = "0.2.0", features = ["print-defmt"] }
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
+panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 
-rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }
+rp2040-hal = { version = "0.4.0", features=["rt", "eh1_0_alpha"] }
 rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
 cortex-m-semihosting = "0.3.7"
 panic-halt = "0.2.0"
@@ -24,6 +25,7 @@ nb = "1.0"
 heapless = "0.7.10"
 no-std-net = "0.6.0"
 httparse = { version = "1.6.0", default-features = false }
+bme280 = { git = "https://github.com/VersBinarii/bme280-rs.git" }
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 rp2040-hal = { version = "0.4.0", features=["rt", "eh1_0_alpha"] }
 rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
 cortex-m-semihosting = "0.3.7"
-panic-halt = "0.2.0"
 nb = "1.0"
 heapless = "0.7.10"
 no-std-net = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ __BME280 to Pico__
 ```
 rustup target install thumbv6m-none-eabi
 cargo install flip-link
-cargo add panic_halt
+cargo install probe-run
 ```
 
 ## Set Up Git Hooks


### PR DESCRIPTION
Adds:

- BME280 support which passes real ambient temperature, pressure, humidity values to Ambi through each HTTP POST request
- Uses `embedded-hal-1.0.0` alongside the 0.2.x series
- [probe-run](https://docs.rs/crate/probe-run/0.3.3) runner (v0.3.3 or above) instead of OpenOCD + gdb runner
- Makes [defmt](https://defmt.ferrous-systems.com/) available for [RTT-based](https://docs.rs/defmt-rtt/latest/defmt_rtt/) debugging output

To test:

- No need for starting OpenOCD anymore, just make sure to switch your Pico A firmware to the [attached uf2 binary](https://github.com/Jim-Hodapp-Coaching/esp32-pico-wifi/files/8612709/raspberry_pi_pico-DapperMime.uf2.zip) instead.


`cargo run`

Note: this should end up being the last major addition to this PoC, all future work will be done in the [esp32-wroom-rp project](https://github.com/Jim-Hodapp-Coaching/esp32-wroom-rp) as a formal Rust crate.