### PR TITLE
Use v0.4.0 of the rp2040-hal dependency instead of using git master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ defmt = "0.2.0"
 defmt-rtt = "0.2.0"
 panic-probe = { version = "0.2.0", features = ["print-defmt"] }
 
-rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }
+rp2040-hal = { version = "0.4.0", features=["rt"] }
 rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
 cortex-m-semihosting = "0.3.7"
 panic-halt = "0.2.0"


### PR DESCRIPTION
Use v0.4.0 of the rp2040-hal dependency instead of using git master. This fixes a duplicate symbol compilation error.