### PR TITLE
Don't panic without a BME280 sensor present

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1215,10 +1215,19 @@ fn connect<D: DelayUs>(
                 timeout -= 1;
             }
             Err(e) => {
+                write!(uart, "Failed to start_client(): {:?}\r\n", e)
+                    .ok()
+                    .unwrap();
                 return Err(e);
             }
         }
     }
+
+    // FIXME: without this delay, we'll frequently see timing issues and receive
+    // a CmdResponseErr. We may not be handling busy/ack flag handling properly
+    // and needs further investigation. I suspect that the ESP32 isn't ready to
+    // receive another command yet.
+    delay.delay_ms(250).ok().unwrap();
 
     timeout = 10000;
     while timeout > 0 {
@@ -1232,7 +1241,7 @@ fn connect<D: DelayUs>(
                 return Err(e);
             }
         }
-        delay.delay_ms(10).ok().unwrap();
+        delay.delay_ms(100).ok().unwrap();
         timeout -= 1;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,11 +369,14 @@ impl SpiDrv {
             match self.read_byte(uart) {
                 Ok(byte_read) => {
                     if byte_read == ERR_CMD {
+                        write!(uart, "\t*** Received ERR_CMD back from ESP32 module\r\n")
+                            .ok()
+                            .unwrap();
                         return Err(SpiDrvError::CmdResponseError);
                     } else if byte_read == wait_byte {
                         return Ok(true);
                     } else if timeout == 0 {
-                        write!(uart, "*** wait_for_byte timed out\r\n")
+                        write!(uart, "\t*** wait_for_byte timed out\r\n")
                             .ok()
                             .unwrap();
                         return Err(SpiDrvError::CmdResponseTimeout);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1695,22 +1695,13 @@ fn main() -> ! {
                     .ok()
                     .unwrap();
 
-                    let t;
-                    let p;
-                    let h;
-                    match bme280_success {
-                        true => {
-                            // Reads live ambient values from the BME280 sensor
-                            let measurements = bme280.measure(&mut delay).unwrap();
-                            t = measurements.temperature;
-                            p = measurements.pressure;
-                            h = measurements.humidity;
-                        }
-                        false => {
-                            t = 23.0;
-                            p = 980.0;
-                            h = 32.0;
-                        }
+                    let measurements;
+                    if bme280_success {
+                        // Reads live ambient values from the BME280 sensor
+                        let m = bme280.measure(&mut delay).unwrap();
+                        measurements = (m.temperature, m.pressure, m.humidity);
+                    } else {
+                            measurements = (23.0, 980.0, 32.0);
                     }
 
                     http_request(
@@ -1720,9 +1711,9 @@ fn main() -> ! {
                         socket,
                         host_address_port,
                         request_path,
-                        t,
-                        h,
-                        p,
+                        measurements.0,
+                        measurements.2,
+                        measurements.1,
                     )
                     .ok()
                     .unwrap();


### PR DESCRIPTION
We used to try and measure with the BME280 sensor no matter what. This would crash when trying to call `measure()`. We no longer do this and it no longer panics.

**Example output of successful error handling with no panics**
```
Making HTTP request to: http://10.0.1.4:4000"/api/readings/add"

                sending byte: 0xE0 -> read byte: 0x[F3]
                sending byte: 0x2D -> read byte: 0x[9F]
                sending byte: 0x4 -> read byte: 0x[BB]
        Sending host IP: 10.0.1.4
                read byte: 0x[3E]
                read bytes: 0x[9F, 2B, D6, 61]
        Sending host port: 4000
                read byte: 0x[EF]
                read byte: 0x[FF, B2]
        Sending socket: 0
                read byte: 0x[7A]
                read bytes: 0x[BF]
        Sending transport_mode: TCP
                read byte: 0x[97]
                read bytes: 0x[E7]
                sending byte (END_CMD): 0x[EE] -> read byte: 0x[5F]
                read byte: 0x()
wait_response_cmd()
        Success: check_start_cmd()
        read_and_check_byte(): 0xAD == 0xAD: true
        Success: read_and_check_byte(cmd | REPLY_FLAG)
        read_and_check_byte(): 0x1 == 0x1: true
        Success: read_and_check_byte(num_param)
        num_param_read: 1
                params[0]: 0x1
        read_and_check_byte(): 0xEE == 0xEE: true
        Success: read_and_check_byte(END_CMD)
        start_client response param: 1
                sending byte: 0xE0 -> read byte: 0x[F3]
                sending byte: 0x2F -> read byte: 0x[9F]
                sending byte: 0x1 -> read byte: 0x[BB]
                read byte: 0x[3E]
                read bytes: 0x[9F]
                sending byte (END_CMD): 0x[EE] -> read byte: 0x[2B]
                read byte: 0x()
wait_response_cmd()
        GET_CLIENT_STATE response Err: CmdResponseError
                sending byte: 0xE0 -> read byte: 0x[EF]
                sending byte: 0x2E -> read byte: 0x[0]
                sending byte: 0x1 -> read byte: 0x[EE]
                read byte: 0x[F3]
                read bytes: 0x[9F]
                sending byte (END_CMD): 0x[EE] -> read byte: 0x[BB]
                read byte: 0x()
wait_response_cmd()
        wait_response_cmd(STOP_CLIENT_TCP) Err: CmdResponseError
** Error encountered while trying to stop ESP32 TCP client.
                sending byte: 0xE0 -> read byte: 0x[EF]    Loop (4) ...
                sending byte: 0x20 -> read byte: 0x[0]
                sending byte: 0x0 -> read byte: 0x[EE]
                sending byte (END_CMD): 0x[EE] -> read byte: 0x[F3]
wait_response_cmd()
        get_connection_status_response Err: CmdResponseError
** Failed to get WiFi connection status
Loop (5) ...    sending byte: 0xE0 -> read byte: 0x[EF]
                sending byte: 0x20 -> read byte: 0x[0]
                sending byte: 0x0 -> read byte: 0x[EE]
                sending byte (END_CMD): 0x[EE] -> read byte: 0x[F3]
wait_response_cmd()
        get_connection_status_response Err: CmdResponseError
** Failed to get WiFi connection status
```