### PR TITLE
Add probe-rs debugging session

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug ESP32 Pico Wifi",
+            "name": "OpenOCD + GDB Debug ESP32 Pico Wifi",
             "request": "launch",
             "type": "cortex-debug",
             "cwd": "${workspaceRoot}",
@@ -27,6 +27,46 @@
                 "break main",
                 "continue"
             ],
+        },
+        // See the following for more config info: https://probe.rs/docs/tools/vscode/#start-a-debug-session-with-minimum-configuration
+        {
+            "preLaunchTask": "Build binary",
+            "type": "probe-rs-debug",
+            "request": "launch",
+            "name": "Probe-rs Debug ESP32 Pico Wifi",
+            "cwd": "${workspaceFolder}",
+            "chip": "rp2040",
+            // RP2040 doesn't support connectUnderReset
+            "connectUnderReset": false,
+            "speed": 4000,
+            "runtimeExecutable": "probe-rs-debugger",
+            "runtimeArgs": [
+                "debug"
+            ],
+            "flashingConfig": {
+                "flashingEnabled": true,
+                "resetAfterFlashing": true,
+                "haltAfterReset": true,
+            },
+            "coreConfigs": [
+                {
+                    "coreIndex": 0,
+                    "programBinary": "target/thumbv6m-none-eabi/debug/esp32-pico-wifi",
+                    "chip": "RP2040",
+                    // Uncomment this if you've downloaded the SVD from
+                    // https://github.com/raspberrypi/pico-sdk/raw/1.3.1/src/rp2040/hardware_regs/rp2040.svd
+                    // and placed it in the .vscode directory
+                    // "svdFile": "./.vscode/rp2040.svd",
+                    "rttEnabled": true,
+                    "options": {
+                        "env": {
+                            "DEFMT_LOG": "debug"
+                        }
+                    },
+                }
+            ],
+            "consoleLogLevel": "Info", //Error, Warn, Info, Debug, Trace
+            "wireProtocol": "Swd"
         }
     ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ codegen-units = 1
 debug = 2
 debug-assertions = true
 incremental = false
-opt-level = 3
+opt-level = 0
 overflow-checks = true
 
 # cargo build/run --release
@@ -53,7 +53,7 @@ debug = 2
 debug-assertions = false
 incremental = false
 lto = 'fat'
-opt-level = 3
+opt-level = 0 # 3
 overflow-checks = false
 
 # do not optimize proc-macro crates = faster builds from scratch

--- a/README.md
+++ b/README.md
@@ -145,6 +145,29 @@ minicom -D /dev/ttyUSB0 -b 115200
 Note that you'll most likely
 need to find the current /dev link assigned to the Pico UART for your particular machine.
 
+## Debugging with VSCode
+
+_Note: these instructions originate from the rp-hal project's [rp2040_project_template README](https://github.com/rp-rs/rp2040-project-template/blob/main/README.md)_
+
+To start a probe-rs debug session:
+
+  *Step 1* - Download [`probe-rs-debugger VSCode plugin 0.4.0`](https://github.com/probe-rs/vscode/releases/download/v0.4.0/probe-rs-debugger-0.4.0.vsix)
+
+  *Step 2* - Install `probe-rs-debugger VSCode plugin`
+  ```console
+  $ code --install-extension probe-rs-debugger-0.4.0.vsix
+  ```
+
+  *Step 3* - Install `probe-rs-debugger`
+  ```console
+  $ cargo install --git https://github.com/probe-rs/probe-rs probe-rs-debugger
+  ```
+
+  *Step 4* - Open this project in VSCode
+
+  *Step 5* - Launch a debug session by choosing `Run`>`Start Debugging` (or press F5)
+
+
 ## License
 
 This project is licensed under the [BSD + Patent license](https://opensource.org/licenses/BSDplusPatent).


### PR DESCRIPTION
Adds VSCode configuration to launch a probe-rs debugging session. See README.md for more information about how to install prerequisites and launch the new VSCode debug target. 